### PR TITLE
add function setResistorRange to allow different shunt resistors

### DIFF
--- a/examples/Continuous_With_Resistor_Value/Continuous_With_Resistor_Value.ino
+++ b/examples/Continuous_With_Resistor_Value/Continuous_With_Resistor_Value.ino
@@ -1,0 +1,105 @@
+/***************************************************************************
+* Example sketch for the INA226_WE library
+*
+* This sketch is based on the continuous mode example but uses the function setResistorRange to set a different resistor value. 
+*  
+* This setup uses a stromsensor6mm board with a 5 mOhm shunt resistor
+* More information on this board can be found here: https://github.com/generationmake/stromsensor6mm
+* 
+***************************************************************************/
+#include <Wire.h>
+#include <INA226_WE.h>
+#define I2C_ADDRESS 0x40
+
+INA226_WE ina226(I2C_ADDRESS);
+// INA226_WE ina226 = INA226_WE(); // Alternative: sets default address 0x40
+
+void setup() {
+  Serial.begin(9600);
+  while(!Serial); // wait until serial comes up on Arduino Leonardo or MKR WiFi 1010
+  Wire.begin();
+  ina226.init();
+
+  /* Set Number of measurements for shunt and bus voltage which shall be averaged
+  * Mode *     * Number of samples *
+  AVERAGE_1            1 (default)
+  AVERAGE_4            4
+  AVERAGE_16          16
+  AVERAGE_64          64
+  AVERAGE_128        128
+  AVERAGE_256        256
+  AVERAGE_512        512
+  AVERAGE_1024      1024
+  */
+  //ina226.setAverage(AVERAGE_16); // choose mode and uncomment for change of default
+
+  /* Set conversion time in microseconds
+     One set of shunt and bus voltage conversion will take: 
+     number of samples to be averaged x conversion time x 2
+     
+     * Mode *         * conversion time *
+     CONV_TIME_140          140 µs
+     CONV_TIME_204          204 µs
+     CONV_TIME_332          332 µs
+     CONV_TIME_588          588 µs
+     CONV_TIME_1100         1.1 ms (default)
+     CONV_TIME_2116       2.116 ms
+     CONV_TIME_4156       4.156 ms
+     CONV_TIME_8244       8.244 ms  
+  */
+  //ina226.setConversionTime(CONV_TIME_1100); //choose conversion time and uncomment for change of default
+  
+  /* Set measure mode
+  POWER_DOWN - INA219 switched off
+  TRIGGERED  - measurement on demand
+  CONTINUOUS  - continuous measurements (default)
+  */
+  //ina226.setMeasureMode(CONTINUOUS); // choose mode and uncomment for change of default
+  
+  /* Set Resistor and Current Range
+     resistor is 5.0 mOhm
+     current range is up to 10.0 A
+     default was 100 mOhm and about 1.3 A
+  */
+  ina226.setResistorRange(0.005,10.0); // choose resistor 5 mOhm and gain range up to 10 A
+  
+  /* If the current values delivered by the INA226 differ by a constant factor
+     from values obtained with calibrated equipment you can define a correction factor.
+     Correction factor = current delivered from calibrated equipment / current delivered by INA226
+  */
+  // ina226.setCorrectionFactor(0.95);
+  
+  Serial.println("INA226 Current Sensor Example Sketch - Continuous");
+  
+  ina226.waitUntilConversionCompleted(); //if you comment this line the first data might be zero
+}
+
+void loop() {
+  float shuntVoltage_mV = 0.0;
+  float loadVoltage_V = 0.0;
+  float busVoltage_V = 0.0;
+  float current_mA = 0.0;
+  float power_mW = 0.0; 
+
+  ina226.readAndClearFlags();
+  shuntVoltage_mV = ina226.getShuntVoltage_mV();
+  busVoltage_V = ina226.getBusVoltage_V();
+  current_mA = ina226.getCurrent_mA();
+  power_mW = ina226.getBusPower();
+  loadVoltage_V  = busVoltage_V + (shuntVoltage_mV/1000);
+  
+  Serial.print("Shunt Voltage [mV]: "); Serial.println(shuntVoltage_mV);
+  Serial.print("Bus Voltage [V]: "); Serial.println(busVoltage_V);
+  Serial.print("Load Voltage [V]: "); Serial.println(loadVoltage_V);
+  Serial.print("Current[mA]: "); Serial.println(current_mA);
+  Serial.print("Bus Power [mW]: "); Serial.println(power_mW);
+  if(!ina226.overflow){
+    Serial.println("Values OK - no overflow");
+  }
+  else{
+    Serial.println("Overflow! Choose higher current range");
+  }
+  Serial.println();
+  
+  delay(3000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -27,6 +27,7 @@ setAverage	KEYWORD2
 setConversionTime	KEYWORD2
 setMeasureMode	KEYWORD2
 setCurrentRange	KEYWORD2
+setResistorRange	KEYWORD2
 getShuntVoltage_mV	KEYWORD2
 getBusVoltage_V	KEYWORD2
 getCurrent_mA	KEYWORD2

--- a/src/INA226_WE.cpp
+++ b/src/INA226_WE.cpp
@@ -89,6 +89,17 @@ void INA226_WE::setCurrentRange(INA226_CURRENT_RANGE range){
 	writeRegister(INA226_CAL_REG, calVal);			
 }
 
+//set resistor and current range independant. resistor value in ohm, current range in A
+void INA226_WE::setResistorRange(float resistor, float current_range){
+	float current_LSB=current_range/32768.0;
+
+	calVal = 0.00512/(current_LSB*resistor);
+	currentDivider_mA = 0.001/current_LSB;
+	pwrMultiplier_mW = 1000.0*25.0*current_LSB;
+
+	writeRegister(INA226_CAL_REG, calVal);			
+}
+
 
 float INA226_WE::getShuntVoltage_mV(){
 	int16_t val;

--- a/src/INA226_WE.h
+++ b/src/INA226_WE.h
@@ -106,6 +106,7 @@ public:
 	void setConversionTime(INA226_CONV_TIME convTime);
 	void setMeasureMode(INA226_MEASURE_MODE mode);
 	void setCurrentRange(INA226_CURRENT_RANGE range);
+	void setResistorRange(float resistor, float range);
 	float getShuntVoltage_mV();
 	float getBusVoltage_V();
 	float getCurrent_mA();


### PR DESCRIPTION
Hi @wollewald 
I made my own sensor board with the INA226 (https://github.com/generationmake/stromsensor6mm). Unfortunately this uses a different shunt resistor and can measure higher current.
So I took your library and added the function setResistorRange to allow different current sense resistor values and current ranges than the predefined. The function calculates the internal variables (calVal, currentDivider_mA, pwrMultiplier_mW) on its own.
I also added an example based on your continuous mode example to show the usage. The example works fine on my hardware and the results are reasonable.
Could you please review my changes and add them to your code? I could also make some changes if necessary.
Thank you
Bernhard 